### PR TITLE
Prevent the conversion of vector data to array by using a for loop.

### DIFF
--- a/src/services/datasource.service.ts
+++ b/src/services/datasource.service.ts
@@ -179,7 +179,9 @@ export class DatasourceService extends DataSourceWithBackend<MyQuery, MyDataSour
     const hasTimeField = frame.fields.find(field => field.type === FieldType.time);
 
     if (hasTimeField) {
-      hasTimeField.values = hasTimeField.values.map(value => value * DatasourceService.MILLISECONDS_IN_SECOND);
+      for (let i = 0; i < hasTimeField.values.length; i++) {
+        hasTimeField.values.set(i, hasTimeField.values.get(i) * DatasourceService.MILLISECONDS_IN_SECOND)
+      }
     }
 
     return frame;


### PR DESCRIPTION
_TLDR:_
Currently this line, on grafana 9 and below will break the graph since the use of `map` will convert the vector into a native array.
By using a for loop, we can prevent any side-effect and keep the data format in a way that doesn't break the grafana 9.x and below.

_Detailed explanations:_
When installing this plugin on our setup of Grafana 9.x we found out that when a dimension of time like `time5minute` is queried, the grafana returns this error:
![Screenshot from 2024-10-17 00-59-36](https://github.com/user-attachments/assets/2f32fd26-7d83-4116-8102-bb18fbfac961)
![Screenshot from 2024-10-17 01-03-07](https://github.com/user-attachments/assets/bd281fc3-4135-4b4d-8102-f01e63174057)

After debugging the code, we have found that this line, will change the type of the data within the `frame` to a native array and thus breaking the grafana since it tries to call the `values.get` function on array which doesn't support the `get` function.

By using a for loop we can ensure that the format is not changed.